### PR TITLE
Fix rows close

### DIFF
--- a/multiTx.go
+++ b/multiTx.go
@@ -118,7 +118,9 @@ func (m *MultiTx) Exec(query string, args ...interface{}) (sql.Result, error) {
 // Implements boil.ContextExecutor.
 func (m *MultiTx) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
 	rows, done, err := multiQuery(m.context(ctx), mtx2Exec(m.tx), query, args...)
-	m.done = append(m.done, done)
+	if done != nil {
+		m.done = append(m.done, done)
+	}
 	return rows, err
 }
 

--- a/multiTx.go
+++ b/multiTx.go
@@ -5,11 +5,16 @@ import (
 	"database/sql"
 )
 
+type ctxCancel struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
 // MultiTx holds a slice of open transactions to multiple nodes.
 // All methods on this type run their sql.Tx variant in one Go routine per Node.
 type MultiTx struct {
-	tx      []*Tx
-	cancels []context.CancelFunc
+	tx   []*Tx
+	ctxs []ctxCancel
 }
 
 // Rollback runs sql.Tx.Rollback on the transactions in separate Go routines.
@@ -27,8 +32,9 @@ type MultiTx struct {
 // Implements boil.Transactor
 func (m *MultiTx) Rollback() error {
 	ec := make(chan error, len(m.tx))
-	for _, cf := range m.cancels {
-		cf()
+	for _, ctx := range m.ctxs {
+		ctx.cancel()
+		<-ctx.ctx.Done()
 	}
 
 	for _, tx := range m.tx {
@@ -78,7 +84,7 @@ func (m *MultiTx) Commit() error {
 
 func (m *MultiTx) context(ctx context.Context) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
-	m.cancels = append(m.cancels, cancel)
+	m.ctxs = append(m.ctxs, ctxCancel{ctx, cancel})
 	return ctx
 }
 

--- a/multiTx_test.go
+++ b/multiTx_test.go
@@ -40,6 +40,7 @@ func TestMultiTx_General(t *testing.T) {
 	}
 	for _, mock := range mocks {
 		mock.ExpectExec(testQuery).WithArgs(1).WillReturnResult(sm.NewResult(2, 3))
+		mock.ExpectRollback()
 	}
 	res, err := tx.ExecContext(context.Background(), testQuery, 1)
 	if err != nil {
@@ -49,6 +50,9 @@ func TestMultiTx_General(t *testing.T) {
 	if err != nil || i != 3 {
 		t.Errorf("ExecContext() Res = %v, want %v", i, 3)
 	}
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Log("Exec")
 	tx, mocks, err = prepareTestTx()
@@ -57,6 +61,7 @@ func TestMultiTx_General(t *testing.T) {
 	}
 	for _, mock := range mocks {
 		mock.ExpectExec(testQuery).WithArgs(1).WillReturnResult(sm.NewResult(2, 3))
+		mock.ExpectRollback()
 	}
 	res, err = tx.Exec(testQuery, 1)
 	if err != nil {
@@ -65,6 +70,9 @@ func TestMultiTx_General(t *testing.T) {
 	i, err = res.RowsAffected()
 	if err != nil || i != 3 {
 		t.Errorf("Exec() Res = %v, want %v", i, 3)
+	}
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
 	}
 
 	want := "value"
@@ -76,6 +84,7 @@ func TestMultiTx_General(t *testing.T) {
 	}
 	for _, mock := range mocks {
 		mock.ExpectQuery(testQuery).WithArgs(1).WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want))
+		mock.ExpectRollback()
 	}
 	rows, err := tx.QueryContext(context.Background(), testQuery, 1)
 	if err != nil {
@@ -89,6 +98,9 @@ func TestMultiTx_General(t *testing.T) {
 	if got != want {
 		t.Errorf("QueryContext() R = %v, want %v", got, want)
 	}
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Log("Query")
 	tx, mocks, err = prepareTestTx()
@@ -97,6 +109,7 @@ func TestMultiTx_General(t *testing.T) {
 	}
 	for _, mock := range mocks {
 		mock.ExpectQuery(testQuery).WithArgs(1).WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want))
+		mock.ExpectRollback()
 	}
 	rows, err = tx.Query(testQuery, 1)
 	if err != nil {
@@ -110,6 +123,9 @@ func TestMultiTx_General(t *testing.T) {
 	if got != want {
 		t.Errorf("Query() R = %v, want %v", got, want)
 	}
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Log("QueryRowContext")
 	tx, mocks, err = prepareTestTx()
@@ -118,6 +134,7 @@ func TestMultiTx_General(t *testing.T) {
 	}
 	for _, mock := range mocks {
 		mock.ExpectQuery(testQuery).WithArgs(1).WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want))
+		mock.ExpectRollback()
 	}
 	row := tx.QueryRowContext(context.Background(), testQuery, 1)
 	got = ""
@@ -127,6 +144,9 @@ func TestMultiTx_General(t *testing.T) {
 	if got != want {
 		t.Errorf("QueryRowContext() R = %v, want %v", got, want)
 	}
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Log("QueryRow")
 	tx, mocks, err = prepareTestTx()
@@ -135,6 +155,7 @@ func TestMultiTx_General(t *testing.T) {
 	}
 	for _, mock := range mocks {
 		mock.ExpectQuery(testQuery).WithArgs(1).WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want))
+		mock.ExpectRollback()
 	}
 	row = tx.QueryRow(testQuery, 1)
 	got = ""
@@ -143,6 +164,10 @@ func TestMultiTx_General(t *testing.T) {
 	}
 	if got != want {
 		t.Errorf("QueryRow() R = %v, want %v", got, want)
+	}
+
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/multiTx_test.go
+++ b/multiTx_test.go
@@ -10,34 +10,12 @@ import (
 )
 
 // Interface implementation checks
-func _() boil.Executor          { return MultiTx{} }
-func _() boil.ContextExecutor   { return MultiTx{} }
-func _() boil.Transactor        { return MultiTx{} }
-func _() boil.ContextTransactor { return MultiTx{} }
+func _() boil.Executor          { return &MultiTx{} }
+func _() boil.ContextExecutor   { return &MultiTx{} }
+func _() boil.Transactor        { return &MultiTx{} }
+func _() boil.ContextTransactor { return &MultiTx{} }
 
-func TestMultiTx_append(t *testing.T) {
-	tests := []struct {
-		name string
-		mtx  MultiTx
-		tx   *Tx
-	}{
-		{
-			"Append",
-			nil,
-			&Tx{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.mtx.append(tt.tx)
-			if len(tt.mtx) != 1 {
-				t.Errorf("mtx.append() len of mtx = %v, want %v", len(tt.mtx), 1)
-			}
-		})
-	}
-}
-
-func prepareTestTx() (MultiTx, []sm.Sqlmock, error) {
+func prepareTestTx() (*MultiTx, []sm.Sqlmock, error) {
 	mdb, mocks, err := multiTestConnect()
 	if err != nil {
 		return nil, nil, err

--- a/multiTx_test.go
+++ b/multiTx_test.go
@@ -3,7 +3,9 @@ package multidb
 import (
 	"context"
 	"database/sql"
+	"math/rand"
 	"testing"
+	"time"
 
 	sm "github.com/DATA-DOG/go-sqlmock"
 	"github.com/volatiletech/sqlboiler/boil"
@@ -39,7 +41,9 @@ func TestMultiTx_General(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, mock := range mocks {
-		mock.ExpectExec(testQuery).WithArgs(1).WillReturnResult(sm.NewResult(2, 3))
+		mock.ExpectExec(testQuery).WithArgs(1).
+			WillReturnResult(sm.NewResult(2, 3)).
+			WillDelayFor(time.Duration(rand.Int63n(100)) * time.Millisecond)
 		mock.ExpectRollback()
 	}
 	res, err := tx.ExecContext(context.Background(), testQuery, 1)
@@ -60,7 +64,9 @@ func TestMultiTx_General(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, mock := range mocks {
-		mock.ExpectExec(testQuery).WithArgs(1).WillReturnResult(sm.NewResult(2, 3))
+		mock.ExpectExec(testQuery).WithArgs(1).
+			WillReturnResult(sm.NewResult(2, 3)).
+			WillDelayFor(time.Duration(rand.Int63n(100)) * time.Millisecond)
 		mock.ExpectRollback()
 	}
 	res, err = tx.Exec(testQuery, 1)
@@ -83,7 +89,9 @@ func TestMultiTx_General(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, mock := range mocks {
-		mock.ExpectQuery(testQuery).WithArgs(1).WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want))
+		mock.ExpectQuery(testQuery).WithArgs(1).
+			WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want)).
+			WillDelayFor(time.Duration(rand.Int63n(100)) * time.Millisecond)
 		mock.ExpectRollback()
 	}
 	rows, err := tx.QueryContext(context.Background(), testQuery, 1)
@@ -108,7 +116,9 @@ func TestMultiTx_General(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, mock := range mocks {
-		mock.ExpectQuery(testQuery).WithArgs(1).WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want))
+		mock.ExpectQuery(testQuery).WithArgs(1).
+			WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want)).
+			WillDelayFor(time.Duration(rand.Int63n(100)) * time.Millisecond)
 		mock.ExpectRollback()
 	}
 	rows, err = tx.Query(testQuery, 1)
@@ -133,7 +143,9 @@ func TestMultiTx_General(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, mock := range mocks {
-		mock.ExpectQuery(testQuery).WithArgs(1).WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want))
+		mock.ExpectQuery(testQuery).WithArgs(1).
+			WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want)).
+			WillDelayFor(time.Duration(rand.Int63n(100)) * time.Millisecond)
 		mock.ExpectRollback()
 	}
 	row := tx.QueryRowContext(context.Background(), testQuery, 1)
@@ -154,7 +166,9 @@ func TestMultiTx_General(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, mock := range mocks {
-		mock.ExpectQuery(testQuery).WithArgs(1).WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want))
+		mock.ExpectQuery(testQuery).WithArgs(1).
+			WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want)).
+			WillDelayFor(time.Duration(rand.Int63n(100)) * time.Millisecond)
 		mock.ExpectRollback()
 	}
 	row = tx.QueryRow(testQuery, 1)

--- a/multidb.go
+++ b/multidb.go
@@ -242,7 +242,7 @@ func (mdb *MultiDB) MultiNode(max int) (MultiNode, error) {
 }
 
 // MultiTx returns a MultiNode with an open transaction
-func (mdb *MultiDB) MultiTx(ctx context.Context, opts *sql.TxOptions, max int) (MultiTx, error) {
+func (mdb *MultiDB) MultiTx(ctx context.Context, opts *sql.TxOptions, max int) (*MultiTx, error) {
 	mn, err := mdb.MultiNode(max)
 	if err != nil {
 		return nil, err

--- a/multidb_test.go
+++ b/multidb_test.go
@@ -656,21 +656,21 @@ func TestMultiDB_MultiTx(t *testing.T) {
 	for _, mock := range mocks {
 		mock.ExpectBegin()
 	}
-	tx, err := mdb.MultiTx(context.Background(), nil, 3)
+	m, err := mdb.MultiTx(context.Background(), nil, 3)
 	if err != nil {
 		t.Error(err)
 	}
-	if len(tx) != 3 {
-		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(tx), 3)
+	if len(m.tx) != 3 {
+		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(m.tx), 3)
 	}
 
 	t.Log("No nodes")
 	mdb.all = nil
-	tx, err = mdb.MultiTx(context.Background(), nil, 3)
+	m, err = mdb.MultiTx(context.Background(), nil, 3)
 	if err == nil || err.Error() != ErrNoNodes {
 		t.Errorf("Expected err: %v, got: %v", sql.ErrConnDone, err)
 	}
-	if tx != nil {
-		t.Errorf("mtx.BeginTx() Res = %v, want %v", tx, nil)
+	if m != nil {
+		t.Errorf("mtx.BeginTx() Res = %v, want %v", m.tx, nil)
 	}
 }

--- a/multinode.go
+++ b/multinode.go
@@ -57,14 +57,16 @@ func (mn MultiNode) Query(query string, args ...interface{}) (*sql.Rows, error) 
 // If you have a choice, stick with a regular QueryContext.
 // This method is primarily included to implement boil.Executor.
 func (mn MultiNode) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
-	return multiQueryRow(ctx, nodes2Exec(mn), query, args...)
+	row, _ := multiQueryRow(ctx, nodes2Exec(mn), query, args...)
+	return row
 }
 
 // QueryRow runs QueryRowContext with context.Background().
 // It is highly recommended to stick with the contexted variant in parallel executions.
 // This method is primarily included to implement boil.Executor.
 func (mn MultiNode) QueryRow(query string, args ...interface{}) *sql.Row {
-	return multiQueryRow(context.Background(), nodes2Exec(mn), query, args...)
+	row, _ := multiQueryRow(context.Background(), nodes2Exec(mn), query, args...)
+	return row
 }
 
 // BeginTx runs sql.DB.BeginTx on the Nodes in separate Go routines.

--- a/multinode.go
+++ b/multinode.go
@@ -38,14 +38,16 @@ func (mn MultiNode) Exec(query string, args ...interface{}) (sql.Result, error) 
 //
 // Implements boil.ContextExecutor.
 func (mn MultiNode) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
-	return multiQuery(ctx, nodes2Exec(mn), query, args...)
+	rows, _, err := multiQuery(ctx, nodes2Exec(mn), query, args...)
+	return rows, err
 }
 
 // Query runs QueryContext with context.Background().
 // It is highly recommended to stick with the contexted variant in parallel executions.
 // This method is primarily included to implement boil.Executor.
 func (mn MultiNode) Query(query string, args ...interface{}) (*sql.Rows, error) {
-	return multiQuery(context.Background(), nodes2Exec(mn), query, args...)
+	rows, _, err := multiQuery(context.Background(), nodes2Exec(mn), query, args...)
+	return rows, err
 }
 
 // QueryRowContext runs sql.DB.QueryRowContext on the Nodes in separate Go routines.

--- a/multinode.go
+++ b/multinode.go
@@ -19,14 +19,16 @@ type MultiNode []*Node
 // It does not make much sense to run this method against multiple Nodes, as they are usually slaves.
 // This method is primarily included to implement boil.ContextExecutor.
 func (mn MultiNode) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	return multiExec(ctx, nodes2Exec(mn), query, args...)
+	res, _, err := multiExec(ctx, nodes2Exec(mn), query, args...)
+	return res, err
 }
 
 // Exec runs ExecContext with context.Background().
 // It is highly recommended to stick with the contexted variant in parallel executions.
 // This method is primarily included to implement boil.Executor.
 func (mn MultiNode) Exec(query string, args ...interface{}) (sql.Result, error) {
-	return multiExec(context.Background(), nodes2Exec(mn), query, args...)
+	res, _, err := multiExec(context.Background(), nodes2Exec(mn), query, args...)
+	return res, err
 }
 
 // QueryContext runs sql.DB.QueryContext on the Nodes in separate Go routines.

--- a/multinode_test.go
+++ b/multinode_test.go
@@ -151,12 +151,12 @@ func TestMultiNode_BeginTx(t *testing.T) {
 	for _, mock := range mocks {
 		mock.ExpectBegin()
 	}
-	tx, err := mn.BeginTx(context.Background(), nil)
+	m, err := mn.BeginTx(context.Background(), nil)
 	if err != nil {
 		t.Error(err)
 	}
-	if len(tx) != 3 {
-		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(tx), 3)
+	if len(m.tx) != 3 {
+		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(m.tx), 3)
 	}
 
 	t.Log("Healty delayed, two error")
@@ -173,12 +173,12 @@ func TestMultiNode_BeginTx(t *testing.T) {
 			mock.ExpectBegin().WillReturnError(sql.ErrConnDone)
 		}
 	}
-	tx, err = mn.BeginTx(context.Background(), nil)
+	m, err = mn.BeginTx(context.Background(), nil)
 	if err != sql.ErrConnDone {
 		t.Errorf("mtx.BeginTx() expected err: %v, got: %v", sql.ErrConnDone, err)
 	}
-	if len(tx) != 1 {
-		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(tx), 1)
+	if len(m.tx) != 1 {
+		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(m.tx), 1)
 	}
 
 	t.Log("All same error")
@@ -191,12 +191,12 @@ func TestMultiNode_BeginTx(t *testing.T) {
 	for _, mock := range mocks {
 		mock.ExpectBegin().WillReturnError(sql.ErrConnDone)
 	}
-	tx, err = mn.BeginTx(context.Background(), nil)
+	m, err = mn.BeginTx(context.Background(), nil)
 	if err != sql.ErrConnDone {
 		t.Errorf("Expected err: %v, got: %v", sql.ErrConnDone, err)
 	}
-	if tx != nil {
-		t.Errorf("mtx.BeginTx() Res = %v, want %v", tx, nil)
+	if m != nil {
+		t.Errorf("mtx.BeginTx() Res = %v, want %v", m.tx, nil)
 	}
 
 	t.Log("Different errors")
@@ -213,7 +213,7 @@ func TestMultiNode_BeginTx(t *testing.T) {
 			mock.ExpectBegin().WillReturnError(sql.ErrConnDone)
 		}
 	}
-	tx, err = mn.BeginTx(context.Background(), nil)
+	m, err = mn.BeginTx(context.Background(), nil)
 	me, ok := err.(MultiError)
 	if !ok {
 		t.Errorf("mtx.BeginTx() expected err type: %T, got: %T", MultiError{}, err)
@@ -221,8 +221,8 @@ func TestMultiNode_BeginTx(t *testing.T) {
 	if len(me.Errors) != 3 {
 		t.Errorf("mtx.BeginTx() len of err = %v, want %v", len(me.Errors), 3)
 	}
-	if tx != nil {
-		t.Errorf("mtx.BeginTx() Res = %v, want %v", tx, nil)
+	if m != nil {
+		t.Errorf("mtx.BeginTx() Res = %v, want %v", m.tx, nil)
 	}
 
 	t.Log("Begin wrapper")
@@ -235,11 +235,11 @@ func TestMultiNode_BeginTx(t *testing.T) {
 	for _, mock := range mocks {
 		mock.ExpectBegin()
 	}
-	tx, err = mn.Begin()
+	m, err = mn.Begin()
 	if err != nil {
 		t.Error(err)
 	}
-	if len(tx) != 3 {
-		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(tx), 3)
+	if len(m.tx) != 3 {
+		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(m.tx), 3)
 	}
 }

--- a/multiquery_test.go
+++ b/multiquery_test.go
@@ -369,7 +369,7 @@ func Test_multiQueryRow(t *testing.T) {
 	for _, mock := range mocks {
 		mock.ExpectQuery(testQuery).WithArgs(1).WillReturnRows(sm.NewRows([]string{"some"}).AddRow(want))
 	}
-	row := multiQueryRow(context.Background(), nodes2Exec(mdb.All()), testQuery, 1)
+	row, done := multiQueryRow(context.Background(), nodes2Exec(mdb.All()), testQuery, 1)
 	var got string
 	if err = row.Scan(&got); err != nil {
 		t.Fatal(err)
@@ -377,6 +377,8 @@ func Test_multiQueryRow(t *testing.T) {
 	if got != want {
 		t.Errorf("multiQueryRow() R = %v, want %v", got, want)
 	}
+
+	<-done
 
 	t.Log("All same error")
 	mdb, mocks, err = multiTestConnect()
@@ -386,7 +388,7 @@ func Test_multiQueryRow(t *testing.T) {
 	for _, mock := range mocks {
 		mock.ExpectQuery(testQuery).WillReturnError(sql.ErrNoRows)
 	}
-	row = multiQueryRow(context.Background(), nodes2Exec(mdb.All()), testQuery, 1)
+	row, done = multiQueryRow(context.Background(), nodes2Exec(mdb.All()), testQuery, 1)
 	got = ""
 	err = row.Scan(&got)
 	if err != sql.ErrNoRows {
@@ -395,4 +397,5 @@ func Test_multiQueryRow(t *testing.T) {
 	if got != "" {
 		t.Errorf("multiQueryRow() Res = %v, want %v", got, "")
 	}
+	<-done
 }

--- a/multiquery_test.go
+++ b/multiquery_test.go
@@ -327,8 +327,9 @@ func Test_multiQuery(t *testing.T) {
 	if rows != nil {
 		t.Errorf("multiQuery() Res = %v, want %v", rows, nil)
 	}
-
-	<-done
+	if done != nil {
+		t.Errorf("multiQuery() Done = %v, want %v", done, nil)
+	}
 
 	t.Log("Different errors")
 	mdb, mocks, err = multiTestConnect()
@@ -353,8 +354,9 @@ func Test_multiQuery(t *testing.T) {
 	if rows != nil {
 		t.Errorf("multiQuery() Res = %v, want %v", rows, nil)
 	}
-
-	<-done
+	if done != nil {
+		t.Errorf("multiQuery() Done = %v, want %v", done, nil)
+	}
 }
 
 func Test_multiQueryRow(t *testing.T) {

--- a/node.go
+++ b/node.go
@@ -8,10 +8,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/moapis/multidb/drivers"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/moapis/multidb/drivers"
 )
 
 const (

--- a/node_test.go
+++ b/node_test.go
@@ -718,7 +718,7 @@ func Test_newEntries(t *testing.T) {
 	wg.Wait() // Allow for the exec go-routines to fire.
 	got := newEntries(nodes)
 	if !reflect.DeepEqual(exp, got) {
-		t.Errorf("newEntries() = %v, want %v", got, exp)
+		t.Errorf("newEntries() = \n%v\nwant\n%v", got, exp)
 	}
 }
 


### PR DESCRIPTION
Fix a bug where `MultiTx.Rollback()` errors due to not properly closed rows. This improves draining, canceling, closing and waiting after queries to solve this issue. 