### PR TITLE
Use sql.Row.Err introduced in Go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: bionic
 
 language: go
 go:
-  - "1.14"
+  - "1.15"
   - master
 
 install:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This makes it an excellent fit for SQLBoiler's auto-generated models.
 
 ## Dependencies
 
-This package has been developed against Go 1.13, with module support and might not work properly on older Go versions.
+This package has been developed against Go 1.15, with module support and will not compile against older Go versions.
 The core package is slim and only depends on the standard Go libraries. 
 Packages in `drivers/` usually depend on their SQL driver counterpart.
 Unit tests pull in some additional packages like `go-sqlmock` and `sqlboiler`.

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/moapis/multidb
 
-go 1.14
+go 1.15
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.4.1
-	github.com/lib/pq v1.7.0
+	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/lib/pq v1.8.0
 	github.com/volatiletech/sqlboiler/v4 v4.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -68,6 +70,8 @@ github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.1-0.20191011153232-f91d3411e481/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.7.0 h1:h93mCPfUSkaul3Ka/VG8uZdmW1uMHDGxzu0NWHuJmHY=
 github.com/lib/pq v1.7.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
+github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/multiTx.go
+++ b/multiTx.go
@@ -136,10 +136,8 @@ func (m *MultiTx) Query(query string, args ...interface{}) (*sql.Rows, error) {
 
 // QueryRowContext runs sql.Tx.QueryRowContext on the tranactions in separate Go routines.
 // The first result is returned immediately, regardless if that result has an error.
-//
-// Errors in sql.Tx.QueryRow are deferred until scan and therefore opaque to this package.
-// If you have a choice, stick with a regular QueryContext.
-// This method is primarily included to implement boil.Executor.
+// The first error free result is returned immediately.
+// If all result sql.Row objects contain an error, only the last Row containing the error is returned.
 func (m *MultiTx) QueryRowContext(ctx context.Context, query string, args ...interface{}) (row *sql.Row) {
 	row, m.done = multiQueryRow(m.context(ctx), mtx2Exec(m.tx), query, args...)
 	return row

--- a/multidb.go
+++ b/multidb.go
@@ -130,10 +130,10 @@ func electMaster(ctx context.Context, nodes []*Node) (*Node, error) {
 	rc := make(chan result, len(available))
 	for _, n := range available {
 		go func(n *Node) {
-			res := result{node: n}
-			if err := n.QueryRowContext(ctx, n.MasterQuery()).Scan(&res.isMaster); err != nil {
-				res.err = n.CheckErr(err) // Should be removed when QueryRowContext becomes error aware
+			res := result{
+				node: n,
 			}
+			res.err = n.QueryRowContext(ctx, n.MasterQuery()).Scan(&res.isMaster)
 			rc <- res
 		}(n)
 	}

--- a/multinode.go
+++ b/multinode.go
@@ -53,11 +53,8 @@ func (mn MultiNode) Query(query string, args ...interface{}) (*sql.Rows, error) 
 }
 
 // QueryRowContext runs sql.DB.QueryRowContext on the Nodes in separate Go routines.
-// The first result is returned immediately, regardless if that result has an error.
-//
-// Errors in sql.DB.QueryRow are deferred until scan and therefore opaque to this package.
-// If you have a choice, stick with a regular QueryContext.
-// This method is primarily included to implement boil.Executor.
+// The first error free result is returned immediately.
+// If all resulting sql.Row objects contain an error, only the last Row containing an error is returned.
 func (mn MultiNode) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
 	row, _ := multiQueryRow(ctx, nodes2Exec(mn), query, args...)
 	return row


### PR DESCRIPTION
This PR enables proper error checking in `QueryRow` variants, after the `sql.Row.Err()` method was added upstream.