### PR TITLE
Optimize core multiplexer functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 
 script:
   - go test -race -coverprofile=codecov.out -covermode=atomic
+  - go test -benchmem -bench . # Just a quick check if the benchmarks are valid
 
 after_script:
   - bash <(curl -s https://codecov.io/bash) -f codecov.out

--- a/multiTx.go
+++ b/multiTx.go
@@ -46,13 +46,16 @@ func (m *MultiTx) Rollback() error {
 			ec <- err
 		}(tx)
 	}
-	var me MultiError
+
+	var errs []error
+
 	for i := 0; i < len(m.tx); i++ {
 		if err := <-ec; err != nil {
-			me.append(err)
+			errs = append(errs, err)
 		}
 	}
-	return me.check()
+
+	return checkMultiError(errs)
 }
 
 // Commit runs sql.Tx.Commit on the transactions in separate Go routines.
@@ -76,13 +79,16 @@ func (m *MultiTx) Commit() error {
 			ec <- tx.Commit()
 		}(tx)
 	}
-	var me MultiError
+
+	var errs []error
+
 	for i := 0; i < len(m.tx); i++ {
 		if err := <-ec; err != nil {
-			me.append(err)
+			errs = append(errs, err)
 		}
 	}
-	return me.check()
+
+	return checkMultiError(errs)
 }
 
 // Context creates a child context and appends CancelFunc in MultiTx

--- a/multiTx_test.go
+++ b/multiTx_test.go
@@ -17,6 +17,113 @@ func _() boil.ContextExecutor   { return &MultiTx{} }
 func _() boil.Transactor        { return &MultiTx{} }
 func _() boil.ContextTransactor { return &MultiTx{} }
 
+func Test_beginMultiTx(t *testing.T) {
+	t.Log("All nodes healthy")
+	mdb, mocks, err := multiTestConnect(defaultTestConns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mn := MultiNode(mdb.All())
+
+	for _, mock := range mocks {
+		mock.ExpectBegin()
+	}
+	txs, err := beginMultiTx(context.Background(), nil, mn.txBeginners()...)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(txs) != 3 {
+		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(txs), 3)
+	}
+
+	t.Log("Healty delayed, two error")
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mn = MultiNode(mdb.All())
+
+	for i, mock := range mocks {
+		if i == 0 {
+			mock.ExpectBegin().WillDelayFor(1 * time.Second)
+		} else {
+			mock.ExpectBegin().WillReturnError(sql.ErrConnDone)
+		}
+	}
+	txs, err = beginMultiTx(context.Background(), nil, mn.txBeginners()...)
+	if err != sql.ErrConnDone {
+		t.Errorf("mtx.BeginTx() expected err: %v, got: %v", sql.ErrConnDone, err)
+	}
+	if len(txs) != 1 {
+		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(txs), 1)
+	}
+
+	t.Log("All same error")
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mn = MultiNode(mdb.All())
+
+	for _, mock := range mocks {
+		mock.ExpectBegin().WillReturnError(sql.ErrConnDone)
+	}
+	txs, err = beginMultiTx(context.Background(), nil, mn.txBeginners()...)
+	if err != sql.ErrConnDone {
+		t.Errorf("Expected err: %v, got: %v", sql.ErrConnDone, err)
+	}
+	if txs != nil {
+		t.Errorf("mtx.BeginTx() Res = %v, want %v", txs, nil)
+	}
+
+	t.Log("Different errors")
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mn = MultiNode(mdb.All())
+
+	for i, mock := range mocks {
+		if i == 0 {
+			mock.ExpectBegin().WillReturnError(sql.ErrNoRows)
+		} else {
+			mock.ExpectBegin().WillReturnError(sql.ErrConnDone)
+		}
+	}
+	txs, err = beginMultiTx(context.Background(), nil, mn.txBeginners()...)
+	me, ok := err.(*MultiError)
+	if !ok {
+		t.Errorf("mtx.BeginTx() expected err type: %T, got: %T", MultiError{}, err)
+	}
+	if len(me.Errors) != 3 {
+		t.Errorf("mtx.BeginTx() len of err = %v, want %v", len(me.Errors), 3)
+	}
+	if txs != nil {
+		t.Errorf("mtx.BeginTx() Res = %v, want %v", txs, nil)
+	}
+}
+
+// benchTxBeginner is simple (no-op) txBeginner implementation
+type benchTxBeginner struct{}
+
+func (*benchTxBeginner) BeginTx(context.Context, *sql.TxOptions) (*Tx, error) {
+	return &Tx{}, nil
+}
+
+func Benchmark_beginMultiTx(b *testing.B) {
+	tbs := make([]txBeginner, benchmarkConns)
+
+	for i := 0; i < benchmarkConns; i++ {
+		tbs[i] = &benchTxBeginner{}
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		beginMultiTx(context.Background(), nil, tbs...)
+	}
+}
+
 func prepareTestTx() (*MultiTx, []sm.Sqlmock, error) {
 	mdb, mocks, err := multiTestConnect(defaultTestConns)
 	if err != nil {

--- a/multiTx_test.go
+++ b/multiTx_test.go
@@ -18,7 +18,7 @@ func _() boil.Transactor        { return &MultiTx{} }
 func _() boil.ContextTransactor { return &MultiTx{} }
 
 func prepareTestTx() (*MultiTx, []sm.Sqlmock, error) {
-	mdb, mocks, err := multiTestConnect()
+	mdb, mocks, err := multiTestConnect(defaultTestConns)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/multiTx_test.go
+++ b/multiTx_test.go
@@ -229,7 +229,7 @@ func TestMultiTx_Rollback(t *testing.T) {
 		}
 	}
 	err = tx.Rollback()
-	me, ok := err.(MultiError)
+	me, ok := err.(*MultiError)
 	if !ok {
 		t.Errorf("mtx.Rollback() expected err type: %T, got: %T", MultiError{}, err)
 	}
@@ -282,7 +282,7 @@ func TestMultiTx_Commit(t *testing.T) {
 		}
 	}
 	err = tx.Commit()
-	me, ok := err.(MultiError)
+	me, ok := err.(*MultiError)
 	if !ok {
 		t.Errorf("mtx.Commit() expected err type: %T, got: %T", MultiError{}, err)
 	}

--- a/multidb_test.go
+++ b/multidb_test.go
@@ -649,7 +649,7 @@ func TestMultiDB_MultiNode(t *testing.T) {
 
 func TestMultiDB_MultiTx(t *testing.T) {
 	t.Log("All nodes healthy")
-	mdb, mocks, err := multiTestConnect()
+	mdb, mocks, err := multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/multidb_test.go
+++ b/multidb_test.go
@@ -273,7 +273,7 @@ func Test_electMaster(t *testing.T) {
 	defer cancel()
 
 	got, err = electMaster(ctx, nodes)
-	_, ok := err.(MultiError)
+	_, ok := err.(*MultiError)
 	if !ok {
 		t.Errorf("electMaster() err = %T, want %T", err, MultiError{})
 	}

--- a/multinode.go
+++ b/multinode.go
@@ -88,7 +88,7 @@ func (mn MultiNode) txBeginners() []txBeginner {
 // but we want to leave the descission whetter to proceed or not, up to the caller.
 func (mn MultiNode) BeginTx(ctx context.Context, opts *sql.TxOptions) (mtx *MultiTx, err error) {
 	mtx = new(MultiTx)
-	mtx.tx, err = beginMultiTx(ctx, opts, mn.txBeginners()...)
+	mtx.tx, err = beginMultiTx(ctx, readOnlyOpts(opts), mn.txBeginners()...)
 	return mtx, err
 }
 

--- a/multinode_test.go
+++ b/multinode_test.go
@@ -214,7 +214,7 @@ func TestMultiNode_BeginTx(t *testing.T) {
 		}
 	}
 	m, err = mn.BeginTx(context.Background(), nil)
-	me, ok := err.(MultiError)
+	me, ok := err.(*MultiError)
 	if !ok {
 		t.Errorf("mtx.BeginTx() expected err type: %T, got: %T", MultiError{}, err)
 	}

--- a/multinode_test.go
+++ b/multinode_test.go
@@ -17,7 +17,7 @@ func _() boil.ContextExecutor { return MultiNode{} }
 // Simple tests for the wrapper methods
 func TestMultiNode_General(t *testing.T) {
 	t.Log("ExecContext")
-	mdb, mocks, err := multiTestConnect()
+	mdb, mocks, err := multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestMultiNode_General(t *testing.T) {
 	}
 
 	t.Log("Exec")
-	mdb, mocks, err = multiTestConnect()
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestMultiNode_General(t *testing.T) {
 	want := "value"
 
 	t.Log("QueryContext")
-	mdb, mocks, err = multiTestConnect()
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestMultiNode_General(t *testing.T) {
 	}
 
 	t.Log("Query")
-	mdb, mocks, err = multiTestConnect()
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestMultiNode_General(t *testing.T) {
 	}
 
 	t.Log("QueryRowContext")
-	mdb, mocks, err = multiTestConnect()
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestMultiNode_General(t *testing.T) {
 	}
 
 	t.Log("QueryRow")
-	mdb, mocks, err = multiTestConnect()
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +142,7 @@ func TestMultiNode_General(t *testing.T) {
 
 func TestMultiNode_BeginTx(t *testing.T) {
 	t.Log("All nodes healthy")
-	mdb, mocks, err := multiTestConnect()
+	mdb, mocks, err := multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestMultiNode_BeginTx(t *testing.T) {
 	}
 
 	t.Log("Healty delayed, two error")
-	mdb, mocks, err = multiTestConnect()
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func TestMultiNode_BeginTx(t *testing.T) {
 	}
 
 	t.Log("All same error")
-	mdb, mocks, err = multiTestConnect()
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestMultiNode_BeginTx(t *testing.T) {
 	}
 
 	t.Log("Different errors")
-	mdb, mocks, err = multiTestConnect()
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestMultiNode_BeginTx(t *testing.T) {
 	}
 
 	t.Log("Begin wrapper")
-	mdb, mocks, err = multiTestConnect()
+	mdb, mocks, err = multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/multinode_test.go
+++ b/multinode_test.go
@@ -2,9 +2,7 @@ package multidb
 
 import (
 	"context"
-	"database/sql"
 	"testing"
-	"time"
 
 	sm "github.com/DATA-DOG/go-sqlmock"
 	"github.com/volatiletech/sqlboiler/v4/boil"
@@ -141,7 +139,6 @@ func TestMultiNode_General(t *testing.T) {
 }
 
 func TestMultiNode_BeginTx(t *testing.T) {
-	t.Log("All nodes healthy")
 	mdb, mocks, err := multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
@@ -158,88 +155,38 @@ func TestMultiNode_BeginTx(t *testing.T) {
 	if len(m.tx) != 3 {
 		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(m.tx), 3)
 	}
+}
 
-	t.Log("Healty delayed, two error")
-	mdb, mocks, err = multiTestConnect(defaultTestConns)
-	if err != nil {
-		t.Fatal(err)
-	}
-	mn = MultiNode(mdb.All())
-
-	for i, mock := range mocks {
-		if i == 0 {
-			mock.ExpectBegin().WillDelayFor(1 * time.Second)
-		} else {
-			mock.ExpectBegin().WillReturnError(sql.ErrConnDone)
-		}
-	}
-	m, err = mn.BeginTx(context.Background(), nil)
-	if err != sql.ErrConnDone {
-		t.Errorf("mtx.BeginTx() expected err: %v, got: %v", sql.ErrConnDone, err)
-	}
-	if len(m.tx) != 1 {
-		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(m.tx), 1)
-	}
-
-	t.Log("All same error")
-	mdb, mocks, err = multiTestConnect(defaultTestConns)
-	if err != nil {
-		t.Fatal(err)
-	}
-	mn = MultiNode(mdb.All())
-
-	for _, mock := range mocks {
-		mock.ExpectBegin().WillReturnError(sql.ErrConnDone)
-	}
-	m, err = mn.BeginTx(context.Background(), nil)
-	if err != sql.ErrConnDone {
-		t.Errorf("Expected err: %v, got: %v", sql.ErrConnDone, err)
-	}
-	if m != nil {
-		t.Errorf("mtx.BeginTx() Res = %v, want %v", m.tx, nil)
-	}
-
-	t.Log("Different errors")
-	mdb, mocks, err = multiTestConnect(defaultTestConns)
-	if err != nil {
-		t.Fatal(err)
-	}
-	mn = MultiNode(mdb.All())
-
-	for i, mock := range mocks {
-		if i == 0 {
-			mock.ExpectBegin().WillReturnError(sql.ErrNoRows)
-		} else {
-			mock.ExpectBegin().WillReturnError(sql.ErrConnDone)
-		}
-	}
-	m, err = mn.BeginTx(context.Background(), nil)
-	me, ok := err.(*MultiError)
-	if !ok {
-		t.Errorf("mtx.BeginTx() expected err type: %T, got: %T", MultiError{}, err)
-	}
-	if len(me.Errors) != 3 {
-		t.Errorf("mtx.BeginTx() len of err = %v, want %v", len(me.Errors), 3)
-	}
-	if m != nil {
-		t.Errorf("mtx.BeginTx() Res = %v, want %v", m.tx, nil)
-	}
-
+func TestMultiNode_Begin(t *testing.T) {
 	t.Log("Begin wrapper")
-	mdb, mocks, err = multiTestConnect(defaultTestConns)
+	mdb, mocks, err := multiTestConnect(defaultTestConns)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mn = MultiNode(mdb.All())
+	mn := MultiNode(mdb.All())
 
 	for _, mock := range mocks {
 		mock.ExpectBegin()
 	}
-	m, err = mn.Begin()
+
+	m, err := mn.Begin()
 	if err != nil {
 		t.Error(err)
 	}
 	if len(m.tx) != 3 {
 		t.Errorf("mtx.BeginTx() len of tx = %v, want %v", len(m.tx), 3)
+	}
+}
+
+func BenchmarkMultiNode_txBeginners(b *testing.B) {
+	mdb, _, err := multiTestConnect(benchmarkConns)
+	if err != nil {
+		b.Fatal(err)
+	}
+	mn := MultiNode(mdb.All())
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		mn.txBeginners()
 	}
 }

--- a/multiquery.go
+++ b/multiquery.go
@@ -54,17 +54,22 @@ type executor interface {
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
-func nodes2Exec(nodes []*Node) (xs []executor) {
-	for _, n := range nodes {
-		xs = append(xs, n)
+func nodes2Exec(nodes []*Node) []executor {
+	xs := make([]executor, len(nodes))
+
+	for i, node := range nodes {
+		xs[i] = node
 	}
 	return xs
 }
 
-func mtx2Exec(mtx []*Tx) (xs []executor) {
-	for _, tx := range mtx {
-		xs = append(xs, tx)
+func mtx2Exec(mtx []*Tx) []executor {
+	xs := make([]executor, len(mtx))
+
+	for i, tx := range mtx {
+		xs[i] = tx
 	}
+
 	return xs
 }
 

--- a/multiquery_test.go
+++ b/multiquery_test.go
@@ -55,44 +55,7 @@ func TestMultiError_Error(t *testing.T) {
 	}
 }
 
-func TestMultiError_append(t *testing.T) {
-	type args struct {
-		err error
-	}
-	tests := []struct {
-		name   string
-		errors []error
-		args   error
-		want   []error
-	}{
-		{
-			"Append",
-			[]error{
-				errors.New("First"),
-				errors.New("Second"),
-			},
-			errors.New("Third"),
-			[]error{
-				errors.New("First"),
-				errors.New("Second"),
-				errors.New("Third"),
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			me := &MultiError{
-				Errors: tt.errors,
-			}
-			me.append(tt.args)
-			if !reflect.DeepEqual(tt.want, me.Errors) {
-				t.Errorf("MultiError.append() = %v, want %v", me.Errors, tt.want)
-			}
-		})
-	}
-}
-
-func TestMultiError_check(t *testing.T) {
+func Test_checkMultiError(t *testing.T) {
 	tests := []struct {
 		name   string
 		errors []error
@@ -110,7 +73,7 @@ func TestMultiError_check(t *testing.T) {
 				errors.New("Second"),
 				errors.New("Third"),
 			},
-			MultiError{
+			&MultiError{
 				[]error{
 					errors.New("First"),
 					errors.New("Second"),
@@ -126,9 +89,8 @@ func TestMultiError_check(t *testing.T) {
 				errors.New("Second"),
 				errors.New("Third"),
 			},
-			MultiError{
+			&MultiError{
 				[]error{
-					nil,
 					errors.New("First"),
 					errors.New("Second"),
 					errors.New("Third"),
@@ -147,10 +109,7 @@ func TestMultiError_check(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			me := MultiError{
-				Errors: tt.errors,
-			}
-			if got := me.check(); !reflect.DeepEqual(got, tt.want) {
+			if got := checkMultiError(tt.errors); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MultiError.check() error = %v, want %v", got, tt.want)
 			}
 		})
@@ -256,7 +215,7 @@ func Test_multiExec(t *testing.T) {
 	if err == nil {
 		t.Errorf("multiExec() expected err got: %v", err)
 	}
-	_, ok := err.(MultiError)
+	_, ok := err.(*MultiError)
 	if !ok {
 		t.Errorf("multiExec() expected err type: %T, got: %T", MultiError{}, err)
 	}
@@ -354,7 +313,7 @@ func Test_multiQuery(t *testing.T) {
 	if err == nil {
 		t.Errorf("multiQuery() expected err got: %v", err)
 	}
-	_, ok := err.(MultiError)
+	_, ok := err.(*MultiError)
 	if !ok {
 		t.Errorf("multiQuery() expected err type: %T, got: %T", MultiError{}, err)
 	}
@@ -529,15 +488,15 @@ go test -benchmem -bench .
 goos: linux
 goarch: amd64
 pkg: github.com/moapis/multidb
-Benchmark_nodes2Exec-8                   1376334               926 ns/op            1792 B/op          1 allocs/op
-Benchmark_mtx2Exec-8                     1200560              1009 ns/op            1792 B/op          1 allocs/op
-Benchmark_multiExec-8                      42184             28397 ns/op            3392 B/op          5 allocs/op
-Benchmark_multiExec_wait-8                 37711             32095 ns/op            3392 B/op          5 allocs/op
-Benchmark_multiQuery-8                     41403             29193 ns/op            3315 B/op          5 allocs/op
-Benchmark_multiQuery_wait-8                27154             44173 ns/op            3300 B/op          5 allocs/op
-Benchmark_multiQueryRow-8                  27008             43920 ns/op            1000 B/op          3 allocs/op
-Benchmark_multiQueryRow_wait-8             27111             44126 ns/op            1000 B/op          3 allocs/op
+Benchmark_nodes2Exec-8                   1411300               917 ns/op            1792 B/op          1 allocs/op
+Benchmark_mtx2Exec-8                     1187618              1013 ns/op            1792 B/op          1 allocs/op
+Benchmark_multiExec-8                      41971             28426 ns/op            3392 B/op          5 allocs/op
+Benchmark_multiExec_wait-8                 37387             31992 ns/op            3392 B/op          5 allocs/op
+Benchmark_multiQuery-8                     40501             28693 ns/op            3308 B/op          3 allocs/op
+Benchmark_multiQuery_wait-8                27075             44565 ns/op            3291 B/op          3 allocs/op
+Benchmark_multiQueryRow-8                  27300             43725 ns/op            1000 B/op          3 allocs/op
+Benchmark_multiQueryRow_wait-8             27147             43747 ns/op            1000 B/op          3 allocs/op
 PASS
-ok      github.com/moapis/multidb       18.840s
+ok      github.com/moapis/multidb       19.108s
 
 */

--- a/multiquery_test.go
+++ b/multiquery_test.go
@@ -506,8 +506,8 @@ go test -benchmem -bench .
 goos: linux
 goarch: amd64
 pkg: github.com/moapis/multidb
-Benchmark_nodes2Exec-8            542857              2375 ns/op            4080 B/op          8 allocs/op
-Benchmark_mtx2Exec-8              460832              2642 ns/op            4080 B/op          8 allocs/op
+Benchmark_nodes2Exec-8           1426524               907 ns/op            1792 B/op          1 allocs/op
+Benchmark_mtx2Exec-8             1195972              1015 ns/op            1792 B/op          1 allocs/op
 Benchmark_multiExec-8              35452             33873 ns/op            3888 B/op          6 allocs/op
 Benchmark_multiQuery-8             17300             68745 ns/op            2110 B/op          5 allocs/op
 Benchmark_multiQueryRow-8          17296             68638 ns/op             210 B/op          3 allocs/op

--- a/multiquery_test.go
+++ b/multiquery_test.go
@@ -488,17 +488,17 @@ go test -benchmem -bench .
 goos: linux
 goarch: amd64
 pkg: github.com/moapis/multidb
-Benchmark_beginMultiTx-8                   19423             58600 ns/op            6976 B/op        205 allocs/op
-BenchmarkMultiNode_txBeginners-8         1402120               931 ns/op            1792 B/op          1 allocs/op
-Benchmark_nodes2Exec-8                   1209753               976 ns/op            1792 B/op          1 allocs/op
-Benchmark_mtx2Exec-8                     1163184              1001 ns/op            1792 B/op          1 allocs/op
-Benchmark_multiExec-8                      40958             29501 ns/op            3394 B/op          5 allocs/op
-Benchmark_multiExec_wait-8                 35953             33132 ns/op            3392 B/op          5 allocs/op
-Benchmark_multiQuery-8                     40780             28957 ns/op            3307 B/op          3 allocs/op
-Benchmark_multiQuery_wait-8                27171             44374 ns/op            3292 B/op          4 allocs/op
-Benchmark_multiQueryRow-8                  26887             44119 ns/op            1000 B/op          3 allocs/op
-Benchmark_multiQueryRow_wait-8             27172             44308 ns/op            1000 B/op          3 allocs/op
+Benchmark_beginMultiTx-8                   24188             46950 ns/op            5280 B/op        103 allocs/op
+BenchmarkMultiNode_txBeginners-8         1382906               936 ns/op            1792 B/op          1 allocs/op
+Benchmark_nodes2Exec-8                   1000000              1017 ns/op            1792 B/op          1 allocs/op
+Benchmark_mtx2Exec-8                     1000000              1015 ns/op            1792 B/op          1 allocs/op
+Benchmark_multiExec-8                      40836             28774 ns/op            3392 B/op          5 allocs/op
+Benchmark_multiExec_wait-8                 36723             32793 ns/op            3392 B/op          5 allocs/op
+Benchmark_multiQuery-8                     42198             29085 ns/op            3306 B/op          3 allocs/op
+Benchmark_multiQuery_wait-8                26955             44723 ns/op            3292 B/op          3 allocs/op
+Benchmark_multiQueryRow-8                  26910             44643 ns/op            1000 B/op          3 allocs/op
+Benchmark_multiQueryRow_wait-8             26415             44659 ns/op            1000 B/op          3 allocs/op
 PASS
-ok      github.com/moapis/multidb       23.063s
+ok      github.com/moapis/multidb       20.978s
 
 */

--- a/multiquery_test.go
+++ b/multiquery_test.go
@@ -488,15 +488,17 @@ go test -benchmem -bench .
 goos: linux
 goarch: amd64
 pkg: github.com/moapis/multidb
-Benchmark_nodes2Exec-8                   1411300               917 ns/op            1792 B/op          1 allocs/op
-Benchmark_mtx2Exec-8                     1187618              1013 ns/op            1792 B/op          1 allocs/op
-Benchmark_multiExec-8                      41971             28426 ns/op            3392 B/op          5 allocs/op
-Benchmark_multiExec_wait-8                 37387             31992 ns/op            3392 B/op          5 allocs/op
-Benchmark_multiQuery-8                     40501             28693 ns/op            3308 B/op          3 allocs/op
-Benchmark_multiQuery_wait-8                27075             44565 ns/op            3291 B/op          3 allocs/op
-Benchmark_multiQueryRow-8                  27300             43725 ns/op            1000 B/op          3 allocs/op
-Benchmark_multiQueryRow_wait-8             27147             43747 ns/op            1000 B/op          3 allocs/op
+Benchmark_beginMultiTx-8                   19423             58600 ns/op            6976 B/op        205 allocs/op
+BenchmarkMultiNode_txBeginners-8         1402120               931 ns/op            1792 B/op          1 allocs/op
+Benchmark_nodes2Exec-8                   1209753               976 ns/op            1792 B/op          1 allocs/op
+Benchmark_mtx2Exec-8                     1163184              1001 ns/op            1792 B/op          1 allocs/op
+Benchmark_multiExec-8                      40958             29501 ns/op            3394 B/op          5 allocs/op
+Benchmark_multiExec_wait-8                 35953             33132 ns/op            3392 B/op          5 allocs/op
+Benchmark_multiQuery-8                     40780             28957 ns/op            3307 B/op          3 allocs/op
+Benchmark_multiQuery_wait-8                27171             44374 ns/op            3292 B/op          4 allocs/op
+Benchmark_multiQueryRow-8                  26887             44119 ns/op            1000 B/op          3 allocs/op
+Benchmark_multiQueryRow_wait-8             27172             44308 ns/op            1000 B/op          3 allocs/op
 PASS
-ok      github.com/moapis/multidb       19.108s
+ok      github.com/moapis/multidb       23.063s
 
 */


### PR DESCRIPTION
This PR brings some mayor optimizations in the Go routine multiplexers, used for Exec, Query and BeginTx on multiple Nodes and transactions. In order to establish the exact overhead of this package, empty `executor` and `txBeginner` implementations are used in the newly added benchmarks.

Some of the optimizations  in `multiquery.go` were done by:

1. Use a single channel (instead of 2) with `result` a struct, containing both the returned type and error. This eliminated the need of nil checks and `select` blocks.
2. Using a single channel, there is no more need for the `WaitGroup` and a channel closing Go routine.
3. The returned `done` channel is eliminated, this speeds execution in the case of `MultiNode`, which does not care when Go routines are done.
4. `MultiTx` requires all routines to be terminated before the next call. Therefore it now passes a `WaitGroup`. When `WaitGroup` is nil, it is not used.

Initial benchmarks, before optimizations:

````
Benchmark_beginMultiTx-8           19423             58600 ns/op            6976 B/op        205 allocs/op
Benchmark_nodes2Exec-8            542857              2375 ns/op            4080 B/op          8 allocs/op
Benchmark_mtx2Exec-8              460832              2642 ns/op            4080 B/op          8 allocs/op
Benchmark_multiExec-8              35452             33873 ns/op            3888 B/op          6 allocs/op
Benchmark_multiQuery-8             17300             68745 ns/op            2110 B/op          5 allocs/op
Benchmark_multiQueryRow-8          17296             68638 ns/op             210 B/op          3 allocs/op
````

Latest benchmarks include additional benchmarks with the optional `WaitGroup`. Those end by `_wait` suffix :

https://github.com/moapis/multidb/blob/fe9b6b9c4251654565337a2a91fd2bd0c0d0765f/multiquery_test.go#L487-L502

The performance overhead of the `Multi*` variants in this package have dropped between 3% and 35%, depending on the type of function and `WaitGroup` involvement, which adds an additional synchronization step.

`MultiError` has also been refactored to simplify its usage and make the code more readable. Additionally, it now purges nil errors before returning a `MultiError`.