### PR TITLE
Return old DBs from mdb.Add and mdb.Delete

### DIFF
--- a/multidb_example_test.go
+++ b/multidb_example_test.go
@@ -42,6 +42,41 @@ var (
 	mdb *MultiDB
 )
 
+func ExampleMultiDB_Add() {
+	const connStr = "user=pqgotest dbname=pqgotest host=%s.moapis.org"
+
+	hosts := []string{
+		"db1",
+		"db2",
+		"db3",
+	}
+
+	for _, host := range hosts {
+		db, err := sql.Open("postgres", fmt.Sprintf(connStr, host))
+		if err != nil {
+			panic(err)
+		}
+
+		if old, ok := mdb.Add(host, db); ok {
+			// Close error ignored, we don't want to interupt
+			// adding of new, healthy nodes.
+			old.Close()
+		}
+	}
+}
+
+func ExampleMultiDB_Delete() {
+	deleted := mdb.Delete("db1", "db2", "db3")
+
+	for name, db := range deleted {
+		if err := db.Close(); err != nil {
+			panic(
+				fmt.Errorf("Closing %s: %w", name, err),
+			)
+		}
+	}
+}
+
 func ExampleMultiDB_AutoMasterSelector() {
 	ms := mdb.AutoMasterSelector(10 * time.Second)
 

--- a/multidb_test.go
+++ b/multidb_test.go
@@ -199,8 +199,29 @@ func TestMultiDB_Add_Delete(t *testing.T) {
 		},
 	}
 
-	mdb.Add("four", new(sql.DB))
-	mdb.Delete("one", "two")
+	if _, ok := mdb.Add("four", new(sql.DB)); ok {
+		t.Error("mdb.Add(): Did not expect returned DB")
+	}
+
+	if _, ok := mdb.Add("three", new(sql.DB)); !ok {
+		t.Error("mdb.Add(): Expected returned DB")
+	}
+
+	want := map[string]*sql.DB{
+		"one": new(sql.DB),
+		"two": new(sql.DB),
+	}
+	got := mdb.Delete("one", "two")
+
+	if len(got) != len(want) {
+		t.Errorf("mdb.Add() =\n%v\nwant\n%v", got, want)
+	}
+
+	for k := range want {
+		if _, ok := got[k]; !ok {
+			t.Errorf("mdb.Add() =\n%v\nwant\n%v", got, want)
+		}
+	}
 
 	mdb.nmu.RLock()
 	mdb.nmu.RUnlock()


### PR DESCRIPTION
This change helps downstream consumers to Close any redundant / discarded DB instances.
- `mdb.Add()` now returns a single `*sql.DB` if one with the same name existed.
- `mdb.Delete()` now returns a map of all deleted `*sql.DB`.

Closes #30